### PR TITLE
Fix a few bad links

### DIFF
--- a/blog/_posts/2020-01-01-happy-new-year-2020.md
+++ b/blog/_posts/2020-01-01-happy-new-year-2020.md
@@ -110,7 +110,7 @@ One of my favorite memories of the year was in Singapore, ~~eavesdropping on~~ l
 
 The biggest news from my day job was that I became the [tech lead](https://en.wikipedia.org/wiki/Lead_programmer) of the project I work on. That could be its own blog post, but for now I'll just say this: before I took the position, I was nervous that I wouldn't have the technical ability required to fill the role. I was afraid that people would have questions I couldn't answer, or that I wouldn't know how to do something. But it turns out that despite its name, the tech lead role isn't really technical at all. It's mostly about people, figuring out what they want and how they interact, and using that to [facilitate cross-team collaboration in a complex organizational structure](https://en.wikipedia.org/wiki/Corporate_jargon).
 
-[![org chart comic](/blog/images/happy-new-year-2020/org-chart.png)]((https://bonkersworld.net/organizational-charts))
+[![org chart comic](/blog/images/happy-new-year-2020/org-chart.png)](https://bonkersworld.net/organizational-charts)
 
 *(Image credit: [Manu Cornet](https://bonkersworld.net/organizational-charts))*
 

--- a/teaching/guides/_posts/2017-02-18-semester.md
+++ b/teaching/guides/_posts/2017-02-18-semester.md
@@ -378,7 +378,7 @@ Libraries let you use code written by other people to expand your own programs.
 
 {% include url-thumbnail.html url="/tutorials/processing/libraries" %}
 
-**Examples and lab ideas:** Pick a library from [the Processing libraries page]((https://processing.org/reference/libraries/) and write a sketch that uses it. You could create a [synthesizer](/examples/processing/libraries/random-synthesizer) or use the Handy renderer.
+**Examples and lab ideas:** Pick a library from [the Processing libraries page](https://processing.org/reference/libraries/) and write a sketch that uses it. You could create a [synthesizer](/examples/processing/libraries/random-synthesizer) or use the Handy renderer.
 
 ---
 

--- a/tutorials/p5js/_posts/2017-10-14-review.md
+++ b/tutorials/p5js/_posts/2017-10-14-review.md
@@ -82,7 +82,7 @@ Either way, the style page looks like this:
 
 {% include codepen.html slug-hash="MJWYNQ" height="qqjzvM" %}
 
-Remember that you can select elemnts by **class** or **ID**, and differnt styles cascade (in other words, combine) to decide the final styling of an element. Learn more about CSS at [the CSS tutorial]](/tutorials/html/css) or on [W3SChools](https://www.w3schools.com/css/) or [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS).
+Remember that you can select elemnts by **class** or **ID**, and differnt styles cascade (in other words, combine) to decide the final styling of an element. Learn more about CSS at [the CSS tutorial](/tutorials/html/css) or on [W3SChools](https://www.w3schools.com/css/) or [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS).
 
 ## JavaScript
 

--- a/tutorials/p5js/for-loops/_posts/2024-01-11-vera-molnar-squares.md
+++ b/tutorials/p5js/for-loops/_posts/2024-01-11-vera-molnar-squares.md
@@ -112,4 +112,4 @@ function drawCell(x, y) {
 
 - Change the number of squares, or play with different colors.
 - Draw different shapes, like circles or polygons.
-- Check out other [art by Vera Molnár]((https://duckduckgo.com/?t=ffab&q=Vera+Moln%C3%A1r+&iax=images&ia=images)) for inspiration!
+- Check out other [art by Vera Molnár](https://duckduckgo.com/?t=ffab&q=Vera+Moln%C3%A1r+&iax=images&ia=images) for inspiration!


### PR DESCRIPTION
Grepped for `]((` and `]](` to find any weird markdown links. Initially spotted the problem on the Vera Molnár link.

Thanks for making this awesome p5js resource! :green_heart: 